### PR TITLE
Instant Skunk Codec

### DIFF
--- a/src/main/scala/Codec.scala
+++ b/src/main/scala/Codec.scala
@@ -1,0 +1,15 @@
+package skunk.codec.extra
+
+import java.time.{Instant, ZoneOffset}
+
+import skunk.Codec
+import skunk.codec.all._
+
+object Temporal {
+  val instant: Codec[Instant] =
+    timestamptz.imap(_.toInstant)(_.atOffset(ZoneOffset.UTC))
+}
+
+package object all {
+  val instant: Codec[Instant] = Temporal.instant
+}

--- a/src/test/resources/migration/V0__Create_Country_Table.sql
+++ b/src/test/resources/migration/V0__Create_Country_Table.sql
@@ -1,5 +1,3 @@
 CREATE TABLE country (
-    id         uuid        CONSTRAINT country_id PRIMARY KEY,
-    name       varchar(40) NOT NULL,
-    created_at date        NOT NULL
+    created_at timestamptz  NOT NULL
 );

--- a/src/test/scala/CodecTest.scala
+++ b/src/test/scala/CodecTest.scala
@@ -35,10 +35,12 @@ class CodecSuite extends munit.FunSuite {
     _ <- DatabaseSession.migrate[IO](flyway)
   } yield ()
 
-  val insert = sql"INSERT INTO country VALUES ($instant)".command
-  val query = sql"SELECT * FROM country".query(instant)
+  val insert = sql"INSERT INTO world.country VALUES ($instant)".command
+  val query = sql"SELECT * FROM world.country".query(instant)
 
   test("codec for Instant") {
+    cleanMigrate().unsafeRunSync()
+
     val test = for {
       pool <- DatabaseSession.pool[IO](db)
     } yield {

--- a/src/test/scala/CodecTest.scala
+++ b/src/test/scala/CodecTest.scala
@@ -1,0 +1,57 @@
+package skunk.codec.extra
+
+import java.time.Instant
+
+import scala.concurrent.ExecutionContext
+
+import cats.effect.{ContextShift, IO, _}
+import natchez.Trace.Implicits.noop
+import skunk.codec.extra.all._
+import skunk.implicits._
+import two.database.config._
+import two.database.session.DatabaseSession
+
+import ExecutionContext.Implicits.global
+
+class CodecSuite extends munit.FunSuite {
+  implicit val CS: ContextShift[IO] =
+    IO.contextShift(global)
+
+  implicit def timer(implicit ec: ExecutionContext): Timer[IO] =
+    IO.timer(ec)
+
+  val db = DatabaseConfig(
+    skunk = SkunkConfig(
+      host = "localhost",
+      database = "world",
+      password = Some("helloworld")
+    )
+  )
+
+  val flyway = FlywayConfig(db.skunk)
+
+  def cleanMigrate(): IO[Unit] = for {
+    _ <- DatabaseSession.clean[IO](flyway)
+    _ <- DatabaseSession.migrate[IO](flyway)
+  } yield ()
+
+  val insert = sql"INSERT INTO country VALUES ($instant)".command
+  val query = sql"SELECT * FROM country".query(instant)
+
+  test("codec for Instant") {
+    val test = for {
+      pool <- DatabaseSession.pool[IO](db)
+    } yield {
+      val now = Instant.now()
+      pool.use { session =>
+        for {
+          _ <- session.prepare(insert).use(_.execute(now))
+          dt <- session.unique(query)
+        } yield assertEquals(dt, now)
+      }
+    }
+
+    test.use(identity).unsafeToFuture()
+  }
+
+}


### PR DESCRIPTION
## Description
- Adds an `extra` package to the skunk codecs
- Created an `Instant` temporal codec for `datetimetz` translations

## Testing
- Integration test

## Issue Resolution
- N/A

## Dependencies
- N/A

## Compatibility
- N/A